### PR TITLE
Updating documentation for actual Meteor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ if (Meteor.isClient) {
 }
 ```
 
-If you use a template, you must do the initialization using **`Template.*myTemplate*.onRendered()`**
+If you use a template, you must do the initialization using **`Template.myTemplate.onRendered()`**
 
 ```javascript
-Template.<template name>.onRendered( function() {
+Template.myTemplate.onRendered( function() {
   Reveal.initialize();
 });
 ```
@@ -105,7 +105,11 @@ For example:
 </head>
 ```
 
-By setting the **`id`** attribute the theme can be changed by calling `Reveal.configure({theme: *theme*})`. 
+By setting the **`id`** attribute the theme can be changed by calling **`Reveal.configure()`**. For example:
+
+```javascript
+Reveal.configure({theme: "moon"});
+```
 
 Demo
 ----

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ if (Meteor.isClient) {
 }
 ```
 
+If you use a template, you must do the initialization using **`Template.*myTemplate*.onRendered()`**
+
+```javascript
+Template.<template name>.onRendered( function() {
+  Reveal.initialize();
+});
+```
+
 You can use configuration values as described in the [documentation of Reveal.js](https://github.com/hakimel/reveal.js#configuration), for example:
 
 ```javascript
@@ -66,12 +74,14 @@ Reveal.configure({ autoSlide: 0 });
 Reveal.configure({ autoSlide: 5000 });
 ```
 
-**CSS**
+**Themes**
 
 You can import one of the built-in theme files, as follow:
 
-```css
-@import "packages/reveal-js/reveal.js/css/theme/<theme_name>.css";
+```html
+<head>
+  <link rel="stylesheet" href="/packages/neo_reveal-js/reveal.js/css/theme/<theme_name>.css" id="theme"/>
+</head>
 ```
 
 Replace **`<theme_name>`** by one of the following built-in themes:
@@ -89,10 +99,13 @@ Replace **`<theme_name>`** by one of the following built-in themes:
 
 For example:
 
-```css
-@import "packages/reveal-js/reveal.js/css/theme/default.css";
+```html
+<head>
+  <link rel="stylesheet" href="/packages/neo_reveal-js/reveal.js/css/theme/<theme_name>.css" id="theme"/>
+</head>
 ```
 
+By setting the **`id`** attribute the theme can be changed by calling `Reveal.configure({theme: *theme*})`. 
 
 Demo
 ----

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ if (Meteor.isClient) {
 }
 ```
 
-If you use a template, you must do the initialization using **`Template.myTemplate.onRendered()`**
+If you use a template, you must do the initialization using **`Template.myTemplate.onRendered()`**.
 
 ```javascript
 Template.myTemplate.onRendered( function() {
@@ -101,7 +101,7 @@ For example:
 
 ```html
 <head>
-  <link rel="stylesheet" href="/packages/neo_reveal-js/reveal.js/css/theme/<theme_name>.css" id="theme"/>
+  <link rel="stylesheet" href="/packages/neo_reveal-js/reveal.js/css/theme/moon.css" id="theme"/>
 </head>
 ```
 


### PR DESCRIPTION
The CSS paths to packaged assets have changed. See https://github.com/meteor/meteor/issues/2602 

I had also troubles using `Reveal.initalize()` in `Meteor.startup()`. 

So, I updated the documentation to give working examples.
